### PR TITLE
Update to Go 1.8 features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ os:
 # version and because we want broader test coverage.
 # NOTE: If you change this version, change its value below in deploy as well.
 go:
-  - 1.7.4
+  - 1.8.x
   - tip
 
 # Allow failure on Go tip, we just want to be able to track behavior there.
@@ -83,8 +83,8 @@ deploy:
     - build/mutagen_windows_amd64.zip
   on:
     repo: havoc-io/mutagen
-    condition: "$TRAVIS_OS_NAME = osx"
-    go: 1.7.4
+    condition: $TRAVIS_OS_NAME = osx
+    condition: $TRAVIS_GO_VERSION =~ ^1\.8\.[0-9]+$
     tags: true
 
 # Send notifications.

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
   allow_failures:
     - go: tip
 
-# Install third-party dependencies.
+# Fetch vendored third-party dependencies.
 before_install:
   - git submodule init
   - git submodule update

--- a/agent/platform.go
+++ b/agent/platform.go
@@ -29,25 +29,20 @@ func unameSIsWindowsPosix(unameS string) bool {
 }
 
 var unameMToGOARCH = map[string]string{
-	"i386":    "386",
-	"i486":    "386",
-	"i586":    "386",
-	"i686":    "386",
-	"x86_64":  "amd64",
-	"amd64":   "amd64",
-	"armv5l":  "arm",
-	"armv6l":  "arm",
-	"armv7l":  "arm",
-	"armv8l":  "arm64",
-	"aarch64": "arm64",
-	// TODO: Add support for 32-bit MIPS architectures (both little-endian and
-	// big-endian) once the ports are released with Go 1.8 and we add the
-	// corresponding agent builds.
-	"mips64":  "mips64",
-	// TODO: Verify that mips64el is the correct Linux uname -m output for
-	// little-endian MIPS64. Note that there is a difference between "el" and
-	// "le", and that Linux returns "ppc64le" for 64-bit little-endian PowerPC
-	// machines, so it's a weird inconsistency.
+	"i386":     "386",
+	"i486":     "386",
+	"i586":     "386",
+	"i686":     "386",
+	"x86_64":   "amd64",
+	"amd64":    "amd64",
+	"armv5l":   "arm",
+	"armv6l":   "arm",
+	"armv7l":   "arm",
+	"armv8l":   "arm64",
+	"aarch64":  "arm64",
+	"mips":     "mips",
+	"mipsel":   "mipsle",
+	"mips64":   "mips64",
 	"mips64el": "mips64le",
 	"ppc64":    "ppc64",
 	"ppc64le":  "ppc64le",

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ init:
 # Disable AppVeyor's default Visual Studio build system.
 build: off
 
-# Install third-party dependencies.
+# Fetch vendored third-party dependencies.
 before_test:
   - git submodule init
   - git submodule update

--- a/cmd/mutagen/prompt.go
+++ b/cmd/mutagen/prompt.go
@@ -30,7 +30,6 @@ func promptMain(arguments []string) error {
 	if messageBase64 == "" {
 		return errors.New("no message specified")
 	}
-	// TODO: In Go 1.8, switch to using the Strict variant of this encoding.
 	messageBytes, err := base64.StdEncoding.DecodeString(messageBase64)
 	if err != nil {
 		return errors.New("unable to decode message")

--- a/filesystem/normalize.go
+++ b/filesystem/normalize.go
@@ -38,15 +38,11 @@ func Normalize(path string) (string, error) {
 		return "", errors.Wrap(err, "unable to perform tilde expansion")
 	}
 
-	// Convert to an absolute path.
+	// Convert to an absolute path. This will also invoke filepath.Clean.
 	path, err = filepath.Abs(path)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to compute absolute path")
 	}
-
-	// Clean the path.
-	// TODO: In Go 1.8, filepath.Abs will call clean, so remove this.
-	path = filepath.Clean(path)
 
 	// Success.
 	return path, nil

--- a/scripts/build.go
+++ b/scripts/build.go
@@ -163,8 +163,12 @@ var targets = []Target{
 	{"linux", "arm64"},
 	{"linux", "ppc64"},
 	{"linux", "ppc64le"},
+	{"linux", "mips"},
+	{"linux", "mipsle"},
 	{"linux", "mips64"},
 	{"linux", "mips64le"},
+	// TODO: This combination is valid but not listed on the "Installing Go from
+	// source" page. Perhaps we should open a pull request to change that?
 	{"linux", "s390x"},
 	{"netbsd", "386"},
 	{"netbsd", "amd64"},
@@ -185,8 +189,6 @@ var targets = []Target{
 	{"solaris", "amd64"},
 	{"windows", "386"},
 	{"windows", "amd64"},
-	// TODO: Add builds for 32-bit MIPS architectures (both little-endian and
-	// big-endian) once the ports are released with Go 1.8.
 }
 
 // TODO: Figure out if we should set this on a per-machine basis. This value is

--- a/session/service.go
+++ b/session/service.go
@@ -151,22 +151,6 @@ func (s *Service) create(stream rpc.HandlerStream) error {
 	return nil
 }
 
-// byCreationTime implements the sort interface for SessionState, sorting
-// sessions by creation time.
-type byCreationTime []SessionState
-
-func (s byCreationTime) Len() int {
-	return len(s)
-}
-
-func (s byCreationTime) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-func (s byCreationTime) Less(i, j int) bool {
-	return timestamp.Less(s[i].Session.CreationTime, s[j].Session.CreationTime)
-}
-
 func (s *Service) list(stream rpc.HandlerStream) error {
 	// Receive the request.
 	var request ListRequest
@@ -214,7 +198,12 @@ func (s *Service) list(stream rpc.HandlerStream) error {
 		}
 
 		// Sort sessions by creation time.
-		sort.Sort(byCreationTime(sessions))
+		sort.Slice(sessions, func(i, j int) bool {
+			return timestamp.Less(
+				sessions[i].Session.CreationTime,
+				sessions[j].Session.CreationTime,
+			)
+		})
 
 		// Send this response.
 		if err := stream.Send(ListResponse{Sessions: sessions}); err != nil {

--- a/session/snapshot.go
+++ b/session/snapshot.go
@@ -9,21 +9,6 @@ import (
 	"github.com/havoc-io/mutagen/sync"
 )
 
-// byName provides the sort interface for StableEntryContent, sorting by name.
-type byName []*StableEntryContent
-
-func (n byName) Len() int {
-	return len(n)
-}
-
-func (n byName) Swap(i, j int) {
-	n[i], n[j] = n[j], n[i]
-}
-
-func (n byName) Less(i, j int) bool {
-	return n[i].Name < n[j].Name
-}
-
 func stableCopy(entry *sync.Entry) *StableEntry {
 	// If the entry is nil, then the copy is nil.
 	if entry == nil {
@@ -46,7 +31,9 @@ func stableCopy(entry *sync.Entry) *StableEntry {
 	}
 
 	// Sort contents by name.
-	sort.Sort(byName(result.Contents))
+	sort.Slice(result.Contents, func(i, j int) bool {
+		return result.Contents[i].Name < result.Contents[j].Name
+	})
 
 	// Done.
 	return result

--- a/ssh/prompt.go
+++ b/ssh/prompt.go
@@ -98,7 +98,6 @@ func prompterEnvironment(prompter, message string) []string {
 	} else {
 		// Convert message to base64 encoding so that we can pass it through the
 		// environment safely.
-		// TODO: In Go 1.8, switch to using the Strict variant of this encoding.
 		messageBase64 := base64.StdEncoding.EncodeToString([]byte(message))
 
 		// Insert necessary environment variables.

--- a/version.go
+++ b/version.go
@@ -1,3 +1,5 @@
+// +build go1.8
+
 package mutagen
 
 import (
@@ -5,12 +7,6 @@ import (
 	"fmt"
 	"io"
 )
-
-// TODO: When Go 1.8 is released, add a build constraint requiring it to this
-// file. In addition to features we'll use in 1.8, there's also an important fix
-// to the compiler in Go 1.7.3 (https://github.com/golang/go/issues/17318) that
-// we require for the rsync package. Unfortunately build constraints aren't
-// available for minor releases.
 
 const (
 	// VersionMajor represents the current major version of Mutagen.


### PR DESCRIPTION
Go 1.8 brings a lot of goodies that are worth using.  Ideally, I'd like to take advantage of the following:

- [X] Enforce usage of Go 1.8 using build constraints
- [X] Update CI systems to use Go 1.8. ~~This is currently blocked by appveyor/ci#1330. We could use Chocolatey to update, but 32-bit support is hard in that case, and AppVeyor usually gets these updates out quickly anyway.~~ AppVeyor has updated to Go 1.8.
- [X] Add support for 32-bit MIPS architectures (little- and big-endian)
- [x] Utilize `sort.Slice`
- [x] Update `filesystem.Normalize` to take advantage of Go 1.8 behavior
- [ ] ~~Switch to using `os.Executable` instead of `kardianos/osext`.~~ Actually, it turns out that the `os.Executable` implementation on OpenBSD uses `procfs` to determine the executable path. This is somewhat more technically correct, but OpenBSD killed support for `procfs`, so this doesn't really work.  The `kardianos/osext` package attempts to find the process using `argv[0]`, which is sufficient for our purposes despite being imperfect. Although in newer versions, it just falls back to `os.Executable` if available, so we'll have to be careful not to use it.
