### PR TITLE
Fix problems with cross-filesystem staging.

### DIFF
--- a/filesystem/atomic.go
+++ b/filesystem/atomic.go
@@ -1,6 +1,7 @@
 package filesystem
 
 import (
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -44,5 +45,61 @@ func WriteFileAtomic(path string, data []byte, permissions os.FileMode) error {
 	}
 
 	// Success.
+	return nil
+}
+
+// RenameFileAtomic performs an atomic file rename. In the simplest case, it's a
+// simple alias for os.Rename. However, if moving a file across filesystems, it
+// will fall back to a copy/rename combination that should still approximate
+// atomicity (at least in terms of swapping the destination file contents). It
+// does NOT support renaming directories, only files. It takes inspiration from:
+// https://github.com/golang/dep/blob/4ad9f4ec24012607dc247ca24528e3224d61519a/fs.go#L80
+func RenameFileAtomic(oldPath, newPath string) error {
+	// Try to peform an atomic rename. If we succeed, or encounter an error that
+	// isn't a cross-device error, then we're done.
+	if err := os.Rename(oldPath, newPath); err == nil {
+		return nil
+	} else if !isCrossDeviceError(err) {
+		return err
+	}
+
+	// Open the source file.
+	source, err := os.Open(oldPath)
+	if err != nil {
+		return errors.Wrap(err, "unable to open source file")
+	}
+
+	// Create a temporary file next to the destination.
+	dirname, basename := filepath.Split(newPath)
+	temporary, err := ioutil.TempFile(dirname, basename)
+	if err != nil {
+		source.Close()
+		return errors.Wrap(err, "unable to create temporary file")
+	}
+	temporaryPath := temporary.Name()
+
+	// Copy the file contents. We'll handle errors below.
+	_, err = io.Copy(temporary, source)
+
+	// Close out files.
+	source.Close()
+	temporary.Close()
+
+	// If there was a copy error, then remove the temporary and abort.
+	if err != nil {
+		os.Remove(temporaryPath)
+		return errors.Wrap(err, "unable to copy file contents")
+	}
+
+	// Move the temporary file into place.
+	if err := os.Rename(temporaryPath, newPath); err != nil {
+		os.Remove(temporaryPath)
+		return errors.Wrap(err, "unable to rename temporary file")
+	}
+
+	// The file is in place. Remove the source file and return. We don't check
+	// for errors on this removal since there's not much point in trying to do
+	// anything about them.
+	os.Remove(oldPath)
 	return nil
 }

--- a/filesystem/atomic_posix.go
+++ b/filesystem/atomic_posix.go
@@ -1,0 +1,16 @@
+// +build !windows
+
+package filesystem
+
+import (
+	"os"
+	"syscall"
+)
+
+func isCrossDeviceError(err error) bool {
+	if linkErr, ok := err.(*os.LinkError); !ok {
+		return false
+	} else {
+		return linkErr.Err == syscall.EXDEV
+	}
+}

--- a/filesystem/atomic_windows.go
+++ b/filesystem/atomic_windows.go
@@ -1,0 +1,25 @@
+package filesystem
+
+import (
+	"os"
+	"syscall"
+)
+
+const (
+	// ERROR_NOT_SAME_DEVICE is the error code returned by MoveFileEx on Windows
+	// when attempting to move a file across devices. This can actually be
+	// avoided on Windows by specifying the MOVEFILE_COPY_ALLOWED flag, but Go's
+	// standard library doesn't do this (most likely to keep consistency with
+	// POSIX, which has no such facility).
+	ERROR_NOT_SAME_DEVICE = 0x11
+)
+
+func isCrossDeviceError(err error) bool {
+	if linkErr, ok := err.(*os.LinkError); !ok {
+		return false
+	} else if errno, ok := linkErr.Err.(syscall.Errno); !ok {
+		return false
+	} else {
+		return errno == ERROR_NOT_SAME_DEVICE
+	}
+}

--- a/sync/transition.go
+++ b/sync/transition.go
@@ -280,7 +280,7 @@ func swap(root, path string, oldEntry, newEntry *Entry, cache *Cache, provider S
 	}
 
 	// Rename the staged file.
-	if err := os.Rename(stagedPath, fullPath); err != nil {
+	if err := filesystem.RenameFileAtomic(stagedPath, fullPath); err != nil {
 		return errors.Wrap(err, "unable to relocate staged file")
 	}
 
@@ -299,7 +299,7 @@ func createFile(root, path string, target *Entry, provider StagingProvider) (*En
 	}
 
 	// Rename the staged file.
-	if err := os.Rename(stagedPath, fullPath); err != nil {
+	if err := filesystem.RenameFileAtomic(stagedPath, fullPath); err != nil {
 		return nil, errors.Wrap(err, "unable to relocate staged file")
 	}
 


### PR DESCRIPTION
Mutagen currently performs staging in a user's home directory on endpoints. But if the target path is not on the same filesystem as the user's home directory on that endpoint, renaming staged files fails with `EXDEV` or similar. This pull request adds a wrapper function that can fall back to a copy-rename-remove-based rename that works across filesystem boundaries.

Fixes #15.
